### PR TITLE
fix: intro-image width

### DIFF
--- a/src/scss/components/_intro-image.scss
+++ b/src/scss/components/_intro-image.scss
@@ -24,7 +24,7 @@
   @include media-breakpoint-up(xl) {
     bottom: -100px;
     left: -70px;
-    width: 850px;
+    width: 770px;
   }
 }
 .intro-image-hide-mobile {


### PR DESCRIPTION
The intro-image was going under the navbar at the xl break-point. I tried to fix that. 

Here is a screenshot of before:
![before screenshot](https://camo.githubusercontent.com/7ac209ee4cca7619a649ad84c3bbf93803c48a0b8fe965417291f6ee84c53c69/68747470733a2f2f7777772e7a65726f7374617469632e696f2f7468656d652f6761747362792d73657269662f6761747362792d73657269662d73637265656e73686f742e706e67)

Here is a screenshot of how it is now:
![Screenshot (267)](https://user-images.githubusercontent.com/74004229/154422307-53586de7-8094-45d3-aebb-7e5ad091a870.png)

This is a beautiful starter!